### PR TITLE
Restructure database

### DIFF
--- a/src/main/java/tech/dttp/block/logger/BlockLogger.java
+++ b/src/main/java/tech/dttp/block/logger/BlockLogger.java
@@ -2,6 +2,7 @@ package tech.dttp.block.logger;
 
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.command.v1.CommandRegistrationCallback;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.event.player.PlayerBlockBreakEvents;
 
 import tech.dttp.block.logger.save.sql.DbConn;
@@ -14,12 +15,11 @@ public class BlockLogger implements ModInitializer {
         CommandRegistrationCallback.EVENT.register((dispatcher, dedicated) -> {
             Commands.register(dispatcher);
         });
-        DbConn.connect();
-        System.out.println("[BL] Connected to database");
+        ServerLifecycleEvents.SERVER_STARTED.register(DbConn::connect);
         PlayerBlockBreakEvents.AFTER.register((world, player, pos, state, entity) -> {
             //SQL
             //Write to database every time a block is broken
-            DbConn.writeBreakPlace(pos.getX(), pos.getY(), pos.getZ(), true, state, player);
+            DbConn.writeBreak(pos.getX(), pos.getY(), pos.getZ(), state, player);
         });
         //todo: Block placement pos via hitresult
     }

--- a/src/main/java/tech/dttp/block/logger/LoggedEventType.java
+++ b/src/main/java/tech/dttp/block/logger/LoggedEventType.java
@@ -1,0 +1,9 @@
+package tech.dttp.block.logger;
+
+public enum LoggedEventType {
+    BREAK,
+    PLACE,
+    CONTAINER,
+    ENTITY_KILL,
+    ENTITY_SPAWN
+}

--- a/src/main/java/tech/dttp/block/logger/command/Commands.java
+++ b/src/main/java/tech/dttp/block/logger/command/Commands.java
@@ -1,42 +1,45 @@
 package tech.dttp.block.logger.command;
 
-import com.mojang.brigadier.Command;
 import com.mojang.brigadier.CommandDispatcher;
-import com.mojang.brigadier.builder.LiteralArgumentBuilder;
-import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
-
 import net.minecraft.command.argument.BlockPosArgumentType;
+import net.minecraft.command.argument.DimensionArgumentType;
 import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.registry.RegistryKey;
+import net.minecraft.world.World;
 import tech.dttp.block.logger.save.sql.DbConn;
 
 import static net.minecraft.server.command.CommandManager.argument;
 import static net.minecraft.server.command.CommandManager.literal;
 
-public final class Commands implements Command<Object> {
+public final class Commands {
 
-    public static void register(CommandDispatcher<ServerCommandSource> dispatcher)
-    {
-    LiteralArgumentBuilder<ServerCommandSource> literalargumentbuilder = literal("bl").
-    then(literal("i").
-        then(argument("pos", BlockPosArgumentType.blockPos()).
-                executes( (c) -> (int)getInteractionsPos(BlockPosArgumentType.getBlockPos(c, "pos")))));
-
-        dispatcher.register(literalargumentbuilder);
+    public static void register(CommandDispatcher<ServerCommandSource> dispatcher) {
+        dispatcher.register(
+                literal("bl")
+                        .requires(scs -> scs.hasPermissionLevel(3))
+                        .then(literal("i")
+                                .then(argument("pos", BlockPosArgumentType.blockPos())
+                                        .then(argument("dimension", DimensionArgumentType.dimension())
+                                                .executes(scs -> getEventsAt(scs.getSource(), BlockPosArgumentType.getBlockPos(scs, "pos"), DimensionArgumentType.getDimensionArgument(scs, "dimension")))
+                                        )
+                                        .executes(scs -> getEventsAt(scs.getSource(), BlockPosArgumentType.getBlockPos(scs, "pos"), null))
+                                )
+                        )
+        );
     }
 
-    private static Object getInteractionsPos(BlockPos pos) {
+    private static int getEventsAt(ServerCommandSource scs, BlockPos pos, ServerWorld world) throws CommandSyntaxException {
+        if (world == null) {
+            world = scs.getPlayer().getServerWorld();
+        }
         int x = pos.getX();
         int y = pos.getY();
         int z = pos.getZ();
-        DbConn.readDataBreakPlace(x, y, z);
+        RegistryKey<World> key = world.getRegistryKey();
+        DbConn.readEvents(x, y, z, key.getValue().getNamespace() + ":" + key.getValue().getPath());
         return 1;
     }
-
-    @Override
-    public int run(CommandContext<Object> context) throws CommandSyntaxException {
-        return 0;
-    }
-
 }

--- a/src/main/java/tech/dttp/block/logger/command/Commands.java
+++ b/src/main/java/tech/dttp/block/logger/command/Commands.java
@@ -39,7 +39,7 @@ public final class Commands {
         int y = pos.getY();
         int z = pos.getZ();
         RegistryKey<World> key = world.getRegistryKey();
-        DbConn.readEvents(x, y, z, key.getValue().getNamespace() + ":" + key.getValue().getPath());
+        DbConn.readEvents(x, y, z, key.getValue().getNamespace() + ":" + key.getValue().getPath(), null);
         return 1;
     }
 }

--- a/src/main/java/tech/dttp/block/logger/save/sql/DbConn.java
+++ b/src/main/java/tech/dttp/block/logger/save/sql/DbConn.java
@@ -4,6 +4,7 @@ import net.minecraft.block.BlockState;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.WorldSavePath;
+import tech.dttp.block.logger.LoggedEventType;
 import tech.dttp.block.logger.util.PlayerUtils;
 
 import java.io.File;
@@ -48,7 +49,7 @@ public class DbConn {
         try {
             String sql = "INSERT INTO events(type, x, y, z, dimension, oldstate, newstate, player, time) VALUES(?,?,?,?,?,?,?,?,?)";
             PreparedStatement ps = con.prepareStatement(sql);
-            ps.setString(1, "break");
+            ps.setString(1, LoggedEventType.BREAK.name());
             ps.setInt(2, x);
             ps.setInt(3, y);
             ps.setInt(4, z);
@@ -65,7 +66,7 @@ public class DbConn {
         }
     }
 
-    public static void readEvents(int x, int y, int z, String dimension) {
+    public static void readEvents(int x, int y, int z, String dimension, LoggedEventType eventType) {
         if (con == null) {
             throw new IllegalStateException("Database connection not initialized");
         }
@@ -74,12 +75,18 @@ public class DbConn {
         try {
             System.out.println("Attempting to read data");
             String sql = "SELECT type,x,y,z,dimension,oldstate,newstate,player,time,rolledbackat FROM events WHERE x=? AND y=? AND z=? AND dimension=?";
+            if (eventType != null) {
+                sql += " AND type=?";
+            }
             System.out.println(sql);
             ps = con.prepareStatement(sql);
             ps.setInt(1, x);
             ps.setInt(2, y);
             ps.setInt(3, z);
             ps.setString(4, dimension);
+            if (eventType != null) {
+                ps.setString(5, eventType.name());
+            }
             rs = ps.executeQuery();
             // Repeat for every entry
             StringBuilder sb = new StringBuilder();

--- a/src/main/java/tech/dttp/block/logger/save/sql/Save.java
+++ b/src/main/java/tech/dttp/block/logger/save/sql/Save.java
@@ -4,9 +4,9 @@ import net.minecraft.block.BlockState;
 import net.minecraft.entity.player.PlayerEntity;
 
 public class Save {
-    public void save(int x, int y, int z, boolean broken, BlockState state, PlayerEntity player){
+    public void saveBreak(int x, int y, int z, BlockState state, PlayerEntity player){
         //Save to database
-        DbConn.writeBreakPlace(x, y, z, broken, state, player);
+        DbConn.writeBreak(x, y, z, state, player);
     }
 
 }

--- a/src/main/java/tech/dttp/block/logger/util/PlayerUtils.java
+++ b/src/main/java/tech/dttp/block/logger/util/PlayerUtils.java
@@ -1,0 +1,12 @@
+package tech.dttp.block.logger.util;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.util.registry.RegistryKey;
+import net.minecraft.world.World;
+
+public class PlayerUtils {
+    public static String getPlayerDimension(PlayerEntity player) {
+        RegistryKey<World> key = player.getEntityWorld().getRegistryKey();
+        return key.getValue().getNamespace() + ":" + key.getValue().getPath();
+    }
+}


### PR DESCRIPTION
This PR restructures the backend database into a format more useable for rolling back damage automatically.
It adds a few fields to the table, namely `type`, which is the type of event that occurred (break, place, kill, etc), dimension which tracks what dimension an event occurred in, oldstate and newstate which are the before and after blockstates of the event, and rolledbackat, which is the unix timestamp at which an event was rolled back, or -1 if it hasn't been.

It also now tracks players by their UUID rather than username to defend against name changing.

The database has been moved to the root folder of the world, on an integrated server it's in .minecraft/saves/world/interactions.bl, on a dedicated server it's in world/interactions.bl

The command has been modified to account for the new dimension tracking, as well as it's code reformatted to be easier to read.

The database loading has been moved to the `SERVER_STARTED` event, to determine where the database file should be located.