### PR TITLE
Add Block placing support

### DIFF
--- a/src/main/java/tech/dttp/block/logger/BlockLogger.java
+++ b/src/main/java/tech/dttp/block/logger/BlockLogger.java
@@ -10,15 +10,17 @@ import tech.dttp.block.logger.command.Commands;
 import tech.dttp.block.logger.util.LoggedEventType;
 
 public class BlockLogger implements ModInitializer {
+    public static DbConn db;
     @Override
     public void onInitialize() {
-        DbConn db = new DbConn();
+
         // Register commands
         CommandRegistrationCallback.EVENT.register((dispatcher, dedicated) -> {
             Commands commands = new Commands();
             commands.register(dispatcher);
         });
         ServerLifecycleEvents.SERVER_STARTED.register((server) -> {
+            db = new DbConn();
             db.connect(server);
         });
         // Block break

--- a/src/main/java/tech/dttp/block/logger/BlockLogger.java
+++ b/src/main/java/tech/dttp/block/logger/BlockLogger.java
@@ -27,7 +27,7 @@ public class BlockLogger implements ModInitializer {
         PlayerBlockBreakEvents.AFTER.register((world, player, pos, state, entity) -> {
             // SQL
             // Write to database every time a block is broken
-            db.writeInteractions(pos.getX(), pos.getY(), pos.getZ(), state, player, world, LoggedEventType.broken);
+            db.writeInteractions(pos.getX(), pos.getY(), pos.getZ(), state, player, world, LoggedEventType.BROKEN);
         });
         // Close DB connection when world is closed
         ServerLifecycleEvents.SERVER_STOPPED.register((server) -> {

--- a/src/main/java/tech/dttp/block/logger/mixin/MixinServerPlayerInteractionManager.java
+++ b/src/main/java/tech/dttp/block/logger/mixin/MixinServerPlayerInteractionManager.java
@@ -1,0 +1,52 @@
+package tech.dttp.block.logger.mixin;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.item.BlockItem;
+import net.minecraft.item.ItemStack;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.network.ServerPlayerInteractionManager;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.Hand;
+import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.util.hit.HitResult;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import tech.dttp.block.logger.BlockLogger;
+import tech.dttp.block.logger.util.LoggedEventType;
+
+@Mixin(ServerPlayerInteractionManager.class)
+public class MixinServerPlayerInteractionManager {
+
+    @Shadow public ServerWorld world;
+
+    @Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;useOnBlock(Lnet/minecraft/item/ItemUsageContext;)Lnet/minecraft/util/ActionResult;", ordinal = 1, shift = At.Shift.AFTER), method = "interactBlock")
+    private void addBlockPlace(ServerPlayerEntity player, World world, ItemStack stack, Hand hand, BlockHitResult hitResult, CallbackInfoReturnable<ActionResult> cir){
+        if (stack.getItem() instanceof BlockItem){
+            BlockItem item = (BlockItem)stack.getItem();
+            BlockState blockState = item.getBlock().getDefaultState();
+            HitResult result = player.raycast(5, 0.0F, true);
+            if (result.getType().equals(HitResult.Type.BLOCK)) {
+                BlockHitResult blockResult = (BlockHitResult)result;
+                BlockLogger.db.writeInteractions(blockResult.getBlockPos().getX(), blockResult.getBlockPos().getY(), blockResult.getBlockPos().getZ(), blockState, player, world, LoggedEventType.placed);
+            }
+        }
+    }
+    @Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;useOnBlock(Lnet/minecraft/item/ItemUsageContext;)Lnet/minecraft/util/ActionResult;", ordinal = 0, shift = At.Shift.AFTER), method = "interactBlock")
+    private void addBlockPlace2(ServerPlayerEntity player, World world, ItemStack stack, Hand hand, BlockHitResult hitResult, CallbackInfoReturnable<ActionResult> cir) {
+        if (stack.getItem() instanceof BlockItem) {
+            BlockItem item = (BlockItem) stack.getItem();
+            BlockState blockState = item.getBlock().getDefaultState();
+            HitResult result = player.raycast(5, 0.0F, true);
+            if (result.getType().equals(HitResult.Type.BLOCK)) {
+                BlockHitResult blockResult = (BlockHitResult) result;
+                BlockLogger.db.writeInteractions(blockResult.getBlockPos().getX(), blockResult.getBlockPos().getY(), blockResult.getBlockPos().getZ(), blockState, player, world, LoggedEventType.placed);
+            }
+        }
+    }
+}

--- a/src/main/java/tech/dttp/block/logger/mixin/MixinServerPlayerInteractionManager.java
+++ b/src/main/java/tech/dttp/block/logger/mixin/MixinServerPlayerInteractionManager.java
@@ -25,6 +25,19 @@ public class MixinServerPlayerInteractionManager {
 
     @Shadow public ServerWorld world;
 
+    /**
+     * Add a mixin that will be called after an item is used. It will do these steps in order
+     *    - Check if the item is a BlockItem
+     *    - If so, get the blockstate and blockitem of that block
+     *    - Then get the block that the player is looking at {@link net.minecraft.entity.Entity#raycast(double, float, boolean)}
+     *    - Check if what the player is looking at is a block
+     *    - if it is a block, then cast to a {@link BlockHitResult}
+     *    - Then write to the database the pos of the block result, the state we gathered earlier,
+     *      the player, the world the player used an item in, and the {@link LoggedEventType#placed}
+     *
+     *      The 2nd mixin just does the same for creative players as well as survival
+     */
+
     @Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;useOnBlock(Lnet/minecraft/item/ItemUsageContext;)Lnet/minecraft/util/ActionResult;", ordinal = 1, shift = At.Shift.AFTER), method = "interactBlock")
     private void addBlockPlace(ServerPlayerEntity player, World world, ItemStack stack, Hand hand, BlockHitResult hitResult, CallbackInfoReturnable<ActionResult> cir){
         if (stack.getItem() instanceof BlockItem){

--- a/src/main/java/tech/dttp/block/logger/util/LoggedEventType.java
+++ b/src/main/java/tech/dttp/block/logger/util/LoggedEventType.java
@@ -1,6 +1,7 @@
 package tech.dttp.block.logger.util;
 
 public enum LoggedEventType {
-    broken,
-    placed
+    BROKEN,
+    PLACED,
+    PLACED_PLAYER_POS
 }


### PR DESCRIPTION
Lets BlockLogger log block placing by a player. It is called after the player places a block.