### PR TITLE
fix relative link to deltalogger

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Blocklogger
-A block change logging tool for the Fabric mod loader. Part of the FabricAdmin suite of tools. Blocklogger is being merged with WatchTower, please see the new repo at [github.com/fabricservertools/deltalogger](github.com/fabricservertools/deltalogger)
+A block change logging tool for the Fabric mod loader. Part of the FabricAdmin suite of tools. Blocklogger is being merged with WatchTower, please see the new repo at [github.com/fabricservertools/deltalogger](https://github.com/fabricservertools/deltalogger)
 #### Join the discord at https://discord.gg/UxHnDWr
 ## Todo
 - [ ] Rollbacks


### PR DESCRIPTION
Hey, apparently the link on the README to the new deltalogger repo is kinda broken. It redirects to `https://github.com/yitzy299/blocklogger/blob/master/github.com/fabricservertools/deltalogger` instead of `https://github.com/fabricservertools/deltalogger`. I checked the source of the README and while I believe the link without `https://` **should** (?) work, it doesn't, so I added it.